### PR TITLE
Fix custom command regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -832,9 +832,9 @@ instance.prototype.actions = function(system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Custom command, must start with 8',
+					label: 'Please refer to PTZOptics VISCA over IP command document for valid commands.',
 					id: 'custom',
-					regex: '/^8[0-9a-fA-F]\\s*([0-9a-fA-F]\\s*)+$/',
+					regex: '/^81 ?([0-9a-fA-F]{2} ?){3,13}[fF][fF]$/',
 					width: 6
 				}
 			]


### PR DESCRIPTION
The custom command REGEX was incorrectly marking commands as invalid when they were in fact valid based on the PTZOptics [command sheet](https://ptzoptics.com/wp-content/uploads/2019/10/PTZOptics-VISCA-over-IP-Commands-Rev1_1.1-10-19.pdf). This PR makes the validation more closely align with the proper command syntax.