### PR TITLE
Add preset and power feedbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -978,51 +978,59 @@ instance.prototype.init_presets = function () {
 		}
 	];
 
-var save;
-for (save = 0; save < 63; save++) {
-	presets.push({
-		category: 'Save Preset',
-		label: 'Save Preset '+ parseInt(save+1) ,
-		bank: {
-			style: 'text',
-			text: 'SAVE\\nPSET\\n' + parseInt(save+1) ,
-			size: '14',
-			color: '16777215',
-			bgcolor: self.rgb(0,0,0),
-		},
-		actions: [
-			{
-				action: 'savePset',
-				options: {
-				val: ('0' + save.toString(16).toUpperCase()).substr(-2,2),
+	var save;
+	for (save = 0; save < 64; save++) {
+		presets.push({
+			category: 'Save Preset',
+			label: 'Save Preset '+ parseInt(save) ,
+			bank: {
+				style: 'text',
+				text: 'SAVE\\nPSET\\n' + parseInt(save) ,
+				size: '14',
+				color: '16777215',
+				bgcolor: self.rgb(0,0,0),
+			},
+			actions: [
+				{
+					action: 'savePset',
+					options: {
+						val: save.toString(16).padStart(2,'0').toUpperCase(),
+					}
 				}
-			}
-		]
-	});
-}
+			]
+		});
+	}
 
-var recall;
-for (recall = 0; recall < 63; recall++) {
-	presets.push({
-		category: 'Recall Preset',
-		label: 'Recall Preset '+ parseInt(recall+1) ,
-		bank: {
-			style: 'text',
-			text: 'Recall\\nPSET\\n' + parseInt(recall+1) ,
-			size: '14',
-			color: '16777215',
-			bgcolor: self.rgb(0,0,0),
-		},
-		actions: [
-			{
-				action: 'recallPset',
-				options: {
-				val: ('0' + recall.toString(16).toUpperCase()).substr(-2,2),
+	var recall;
+	for (recall = 0; recall < 64; recall++) {
+		presets.push({
+			category: 'Recall Preset',
+			label: 'Recall Preset '+ parseInt(recall) ,
+			bank: {
+				style: 'text',
+				text: 'Recall\\nPSET\\n' + parseInt(recall) ,
+				size: '14',
+				color: '16777215',
+				bgcolor: self.rgb(0,0,0),
+			},
+			actions: [
+				{
+					action: 'recallPset',
+					options: {
+						val: recall.toString(16).padStart(2,'0').toUpperCase(),
+					}
 				}
-			}
-		]
-	});
-}
+			],
+			feedbacks: [
+				{
+					type: 'active_preset',
+					options : {
+						val: recall.toString(16).padStart(2,'0').toUpperCase(),
+					}
+				}
+			]
+		});
+	}
 
 	self.setPresetDefinitions(presets);
 };

--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ var SHUTTER = [
 ];
 
 var PRESET = [];
-for (var i = 0; i < 64; ++i) {
-	PRESET.push({ id: ('0' + i.toString(16)).substr(-2,2), label: 'Preset ' + i });
+for (var i = 0; i < 128; ++i) {
+	PRESET.push({ id: i.toString(16).padStart(2,'0').toUpperCase(), label: 'Preset ' + i });
 }
 
 var SPEED = [

--- a/index.js
+++ b/index.js
@@ -1527,7 +1527,7 @@ instance.prototype.action = function(action) {
 
 		case 'custom':
 			var hexData = opt.custom.replace(/\s+/g, '');
-			var tempBuffer = new Buffer(hexData, 'hex');
+			var tempBuffer = Buffer.from(hexData, 'hex');
 			cmd = tempBuffer.toString('binary');
 
 			if ((tempBuffer[0] & 0xF0) === 0x80) {

--- a/index.js
+++ b/index.js
@@ -1225,7 +1225,11 @@ instance.prototype.actions = function(system) {
 					type: 'dropdown',
 					label: 'power on/off',
 					id: 'bool',
-					choices: [{ id: 'off', label:'off'},{ id: 'on', label:'on'}]
+					default: 'off',
+					choices: [
+						{ id: 'off', label:'off'},
+						{ id: 'on', label:'on'}
+					]
 				}
 			]
 		},


### PR DESCRIPTION
I've been finding a need to be able to know what preset the camera is currently at. Unfortunately the [PTZ Optics visca over IP API](https://ptzoptics.com/wp-content/uploads/2019/10/PTZOptics-VISCA-over-IP-Commands-Rev1_1.1-10-19.pdf) does not offer a way to query the camera to know if it's currently on a preset. That would have made things significantly more simple. Instead, we have to keep track of the preset in the software. This PR is an attempt at making that possible.

In addition to the preset feedback, I've also added a feedback to display if the camera is on or off. Again, this cannot be queried from the camera, so the software cannot know the actual power state until a power on or off command is sent to the camera.

![feedback-preset](https://user-images.githubusercontent.com/221971/99336973-82fbce80-284f-11eb-81a9-5478d5ae7a47.gif)

I do not update the feedbacks until we receive an associated "command complete" response from the camera. This is to make the feedback more accurate to the actual state of the camera.

Because I have to hold state in the software, there are opportunities for the state to get out of sync if something weird happens. I've tried to account for everything I experienced in my testing against a real camera, so hopefully this won't happen. I think time will tell if there's a bug in here somewhere.

This PR also fixes an issue where the power on command would not work the first time it is used. In addition to that, this PR lays the foundation for enabling [inquiry commands to update dynamic variables](https://github.com/bitfocus/companion-module-ptzoptics-visca/issues/2) and also gives a power feedback as requested in #4.
