### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -1112,7 +1112,7 @@ instance.prototype.action = function(action) {
 
 		case 'custom':
 			var hexData = opt.custom.replace(/\s+/g, '');
-			var tempBuffer = new Buffer(hexData, 'hex');
+			var tempBuffer = Buffer.from(hexData, 'hex');
 			cmd = tempBuffer.toString('binary');
 
 			if ((tempBuffer[0] & 0xF0) === 0x80) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ptzoptics-visca",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Protocol",
@@ -8,7 +8,6 @@
 	"manufacturer": "PTZoptics",
 	"product": "VISCA",
 	"shortname": "visca",
-	"description": "PTZoptics VISCA module",
 	"description": "Module to control PTZ cameras with PTZoptics Visca protocol over IP",
 	"main": "index.js",
 	"sponsored": [ "Arvol Dingess <adingess@toucanproductions.net>" ],


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/