### PR TITLE
Use static-text, not text, for the Information config-field

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class PtzOpticsInstance extends InstanceBase {
 	getConfigFields() {
 		return [
 			{
-				type: 'text',
+				type: 'static-text',
 				id: 'info',
 				width: 12,
 				label: 'Information',


### PR DESCRIPTION
Not working in Companion tip, tho I feel like it might have been in whatever stable release I first started noodling around in.  Missed in the 3.0 conversion maybe?