### PR TITLE
Add actions and presets to turn on/off auto tracking

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -492,6 +492,27 @@ exports.getActions = function (instance) {
 				instance.sendVISCACommand(cmd)
 			},
 		},
+		autoTracking: {
+			name: 'Auto Tracking',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Auto Tracking (PTZ Optics G3 model required)',
+					id: 'tracking',
+					choices: [
+						{ id: 'off', label: 'Off' },
+						{ id: 'on', label: 'On' },
+					],
+				},
+			],
+			callback: async (event) => {
+				// PTZOptics G3 VISCA over IP Commands, 10/27/2023:
+				// 81 0A 11 54 0p FF, p: 0x2=On, 0x3=Off
+				const b = event.options.tracking === 'on' ? '\x02' : '\x03'
+				const cmd = '\x81\x0A\x11\x54' + b + '\xFF'
+				instance.sendVISCACommand(cmd)
+			},
+		},
 		custom: {
 			name: 'Custom command',
 			options: [

--- a/presets.js
+++ b/presets.js
@@ -749,6 +749,58 @@ exports.getPresets = function () {
 		feedbacks: [],
 	}
 
+	presets['auto_tracking_on'] = {
+		type: 'button',
+		category: 'Auto Tracking',
+		name: 'Auto Tracking On',
+		style: {
+			text: 'Auto\\nTracking\\nOn',
+			size: '14',
+			color: '16777215',
+			bgcolor: combineRgb(0, 0, 0),
+		},
+		steps: [
+			{
+				down: [
+					{
+						actionId: 'autoTracking',
+						options: {
+							tracking: 'on',
+						},
+					},
+				],
+				up: [],
+			},
+		],
+		feedbacks: [],
+	}
+
+	presets['auto_tracking_off'] = {
+		type: 'button',
+		category: 'Auto Tracking',
+		name: 'Auto Tracking Off',
+		style: {
+			text: 'Auto\\nTracking\\nOff',
+			size: '14',
+			color: '16777215',
+			bgcolor: combineRgb(0, 0, 0),
+		},
+		steps: [
+			{
+				down: [
+					{
+						actionId: 'autoTracking',
+						options: {
+							tracking: 'off',
+						},
+					},
+				],
+				up: [],
+			},
+		],
+		feedbacks: [],
+	}
+
 	// generates presets for saving camera presets
 	for (var save = 0; save < 255; save++) {
 		if (save < 90 || save > 99) {


### PR DESCRIPTION
The latest PTZOptics G3-era cameras have auto tracking support, for maintaining focus on something that moves around (like say some pastors during sermons).

It's possible to use custom command support for these actions, but there really should be a dedicated action and presets.

This PR really is only the final commit -- the rest of the new commits are to be dealt with in #30.  I don't know if/how the Github tracker exposes PRs that depend upon PRs.

It might be preferable to have something like an option to specify your camera model (...and firmware?  the [firmware changelog](https://ptzoptics.com/firmware-changelog/) indicates they sometimes add VISCA commands in firmware updates).  Then actions/presets like this would only be exposed if your camera model supports them.  bmd-atem has this, but then BMD has lots and lots more models than PTZOptics has camera models.  So perhaps that particular yak can be at least deferred to a followup.