### PR TITLE
Rename references to power "off" to "standby" 

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -362,7 +362,7 @@ export function getActions(instance: PtzOpticsInstance): CompanionActionDefiniti
 			options: [
 				{
 					type: 'dropdown',
-					label: 'power on/off',
+					label: 'power on/standby',
 					id: CameraPowerOption.id,
 					choices: CameraPowerOption.choices,
 					default: CameraPowerOption.default,

--- a/src/camera/options.ts
+++ b/src/camera/options.ts
@@ -156,7 +156,7 @@ export const ShutterSetOption = {
 export const CameraPowerOption = {
 	id: 'bool',
 	choices: [
-		{ id: 'off', label: 'off' },
+		{ id: 'off', label: 'standby' },
 		{ id: 'on', label: 'on' },
 	],
 	default: 'on',


### PR DESCRIPTION
The camera isn't actually off, so best to be truthful.