### PR TITLE
Don't delay init() to fully establish the connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ptzoptics-visca",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"type": "module",
 	"main": "dist/main.js",
 	"scripts": {

--- a/src/visca/__tests__/camera-connected.test.ts
+++ b/src/visca/__tests__/camera-connected.test.ts
@@ -1,0 +1,29 @@
+import { InstanceStatus } from '@companion-module/base'
+import { describe, test } from '@jest/globals'
+import { InstanceStatusIs, WaitUntilConnectedToCamera } from './camera-interactions/interactions.js'
+import { RunCameraInteractionTest } from './camera-interactions/run-test.js'
+
+describe('port connected', () => {
+	test('wait for connection explicitly', async () => {
+		return RunCameraInteractionTest(
+			[
+				// Operations to initiate a connection have occurred, but (as
+				// the code exists now) we haven't yet returned to the event
+				// loop (which will allow the connection to be established) --
+				// so we're still connecting here.
+				InstanceStatusIs(InstanceStatus.Connecting),
+				WaitUntilConnectedToCamera(),
+			],
+			InstanceStatus.Ok
+		)
+	})
+
+	// It would be *really* nice to test that for a port that's been opened and
+	// `connect()` immediately called, closing before the `connect()` resolves
+	// will cause the `connect()` to reject with an error with the provided
+	// closure reason as message.  To do this, the connection triggered by the
+	// port can't be established *too quickly*.  That seems nearly impossible to
+	// replicate with a purely local server and connection (and node:net doesn't
+	// expose a way to artificially delay connection establishment), so we do
+	// without for now.
+})

--- a/src/visca/__tests__/camera-interactions/interactions.ts
+++ b/src/visca/__tests__/camera-interactions/interactions.ts
@@ -78,6 +78,10 @@ type CloseVISCAPort = {
 	readonly type: 'close-visca-port'
 }
 
+type WaitForConnection = {
+	readonly type: 'wait-for-connection'
+}
+
 /**
  * An interaction to perform during a camera interaction sequence test using
  * `RunCameraInteractionTest`.
@@ -95,6 +99,7 @@ export type Interaction =
 	| InquiryFatalFailure
 	| InstanceStatusCheck
 	| CloseVISCAPort
+	| WaitForConnection
 
 /**
  * Send a command that has options through the VISCA port.
@@ -260,4 +265,18 @@ export function InstanceStatusIs(status: InstanceStatus): InstanceStatusCheck {
  */
 export function CloseVISCAPortEarly(): CloseVISCAPort {
 	return { type: 'close-visca-port' }
+}
+
+/**
+ * Wait for the port to be fully connected to the camera if it isn't already.
+ * (It's allowed for the connection to already be established.)
+ *
+ * "Opening" a port doesn't wait for a connection to be established, in order
+ * that it can complete quickly: subsequent actions that depend on full
+ * connection will wait until an "opened" connection is established.  This
+ * interaction manually performs that waiting; the only visible effect right now
+ * is to guarantee the instance status is `Ok` and not possibly `Connecting`.
+ */
+export function WaitUntilConnectedToCamera(): WaitForConnection {
+	return { type: 'wait-for-connection' }
 }

--- a/src/visca/__tests__/camera-interactions/matchers.ts
+++ b/src/visca/__tests__/camera-interactions/matchers.ts
@@ -26,7 +26,7 @@ export const InquiryResponseWithoutInquiryMatcher = /^Received inquiry response 
 export const ErrorOfUnexpectedLengthMatcher = /^Encountered error response of unexpected length/
 export const UnrecognizedErrorMatcher = /^Received error response to \[[0-9A-Z ]+\] with unrecognized format/
 
-export const SocketClosedMatcher = 'Message not fully processed: socket was closed'
+export const SocketClosedMatcher = 'Socket was closed'
 
 export const AttemptSendInvalidMatcher = /^Attempt to send invalid /
 

--- a/src/visca/__tests__/camera-interactions/run-test.ts
+++ b/src/visca/__tests__/camera-interactions/run-test.ts
@@ -62,7 +62,7 @@ function checkInquirySucceeded(expectedResponse: CompanionOptionValues, actualRe
  * updates.
  */
 class MockInstance implements PartialInstance {
-	currentStatus = InstanceStatus.Disconnected
+	currentStatus = InstanceStatus.UnknownError
 
 	log = (level: LogLevel, msg: string) => {
 		LOG(`Log (${level}): ${msg}`)
@@ -169,21 +169,24 @@ type Camera = {
 	 * bytes.
 	 */
 	readIncomingBytes: (amount: number) => Promise<readonly number[]>
+
+	/**
+	 * A promise that resolves when the "camera"'s incoming connection socket
+	 * closes, resolving `true` if there was a connection error (i.e. the
+	 * `VISCAPort` was manually closed, terminating the connection) and `false`
+	 * otherwise.
+	 */
+	socketClosed: Promise<boolean>
 }
 
 /**
- * Perform the interactions specified by `interactions` using the opened
- * `clientViscaPort` connected to `camera`, with the `instance` used to
- * construct `clientViscaPort`.  Close `camera` and `clientViscaPort` when
- * interactions are finished (including in case of error).
+ * Perform the interactions specified by `interactions` using a fresh
+ * `VISCAPort`.
  *
- * @param clientViscaPort
- *   A port through which VISCA commands and inquiries can be sent and their
- *   responses received, on which an `open` call has resolved.
- * @param camera
- *   The mock camera used in this test, to which `clientViscaPort` is connected.
- * @param instance
- *   The mock instance used to create `visca`.
+ * @param server
+ *   A server that performs the functions of a mock camera.
+ * @param port
+ *   The TCP port the camera mocked by `server` is running on.
  * @param interactions
  *   An array of the interactions to perform.  The array must be "complete" in
  *   that all sent commands and inquiries must have their responses expected and
@@ -192,20 +195,68 @@ type Camera = {
  *    The expected status of `instance` after all interactions have completed.
  */
 async function verifyInteractions(
-	clientViscaPort: VISCAPort,
-	camera: Camera,
-	instance: MockInstance,
+	server: net.Server,
+	port: number,
 	interactions: readonly Interaction[],
 	finalStatus: InstanceStatus
 ): Promise<void> {
-	LOG(`Mock camera running on port ${camera.socket.localPort}`)
+	const instance = new MockInstance()
+	const clientViscaPort = new VISCAPort(instance)
 
-	let cameraSocketCloseExpectsError = false
-	const cameraSocketClosed = new Promise<boolean>((resolve: (hadError: boolean) => void) => {
-		camera.socket.once('close', (hadError: boolean) => {
-			resolve(hadError)
+	const camera = new Promise<Camera>((resolve: (camera: Camera) => void) => {
+		server.once('connection', (socket: net.Socket) => {
+			LOG(`Server received connection on port ${socket.localPort}`)
+
+			const socketClosed = new Promise<boolean>((resolve: (hadError: boolean) => void) => {
+				socket.once('close', (hadError: boolean) => {
+					resolve(hadError)
+				})
+			})
+
+			const cameraIncomingBytes: number[] = []
+			let cameraSocketError = false
+			socket.once('error', (_err: Error) => {
+				cameraSocketError = true
+			})
+
+			let cameraReceivedMoreBytes = (async function cameraWaitToReceiveBytes() {
+				return new Promise<void>((resolve: () => void) => {
+					socket.once('data', (data: Buffer) => {
+						if (cameraSocketError) {
+							return
+						}
+
+						cameraIncomingBytes.push(...data)
+						resolve()
+
+						cameraReceivedMoreBytes = cameraWaitToReceiveBytes()
+					})
+				})
+			})()
+
+			async function readIncomingBytes(amount: number): Promise<readonly number[]> {
+				if (amount < 0) {
+					amount = cameraIncomingBytes.length
+				}
+				while (cameraIncomingBytes.length < amount) {
+					await cameraReceivedMoreBytes
+				}
+				return cameraIncomingBytes.splice(0, amount)
+			}
+
+			const camera = { server, socket, readIncomingBytes, socketClosed }
+			resolve(camera)
 		})
 	})
+
+	// Unless the VISCAPort is closed, the socket that the camera sees shouldn't
+	// close with an error.
+	let cameraSocketCloseExpectsError = false
+
+	// NOTE: This doesn't wait for the connection to be fully established.
+	//       Operations must either implicitly wait for it to be established or
+	//       `connect()` must be awaited.
+	clientViscaPort.open('127.0.0.1', port, true)
 
 	try {
 		const sentCommands: Map<string, Promise<void | Error>> = new Map()
@@ -231,7 +282,7 @@ async function verifyInteractions(
 				case 'camera-expect-incoming-bytes': {
 					const { bytes: expectedBytes } = interaction
 					LOG(`Camera receiving ${expectedBytes.length} bytes`)
-					const incomingBytes = await camera.readIncomingBytes(expectedBytes.length)
+					const incomingBytes = await (await camera).readIncomingBytes(expectedBytes.length)
 					if (
 						!incomingBytes.every((v: number, i: number) => {
 							return v === expectedBytes[i]
@@ -245,7 +296,7 @@ async function verifyInteractions(
 				}
 				case 'camera-reply': {
 					const { bytes } = interaction
-					if (!camera.socket.write(bytes)) {
+					if (!(await camera).socket.write(bytes)) {
 						throw new Error(`Writing ${prettyBytes([...bytes])} failed, socket closed`)
 					}
 					LOG(`Wrote ${prettyBytes([...bytes])} to socket`)
@@ -403,6 +454,20 @@ async function verifyInteractions(
 					cameraSocketCloseExpectsError = true
 					break
 				}
+				case 'wait-for-connection': {
+					const { currentStatus: beforeStatus } = instance
+					if (![InstanceStatus.Connecting, InstanceStatus.Ok].includes(beforeStatus)) {
+						throw new Error(`Connection should be connecting or connected, instead was ${repr(beforeStatus)}`)
+					}
+
+					await clientViscaPort.connect()
+
+					const afterStatus = instance.currentStatus
+					if (afterStatus !== InstanceStatus.Ok) {
+						throw new Error(`Instance status should be Ok after connect(), was ${repr(afterStatus)}`)
+					}
+					break
+				}
 				default:
 					assertNever(type)
 					break
@@ -431,10 +496,12 @@ async function verifyInteractions(
 		LOG('interaction testing finished')
 		clientViscaPort.close()
 
+		const { socketClosed: cameraSocketClosed, server } = await camera
+
 		const hadErrorClosingCameraSocket = await cameraSocketClosed
 
 		await new Promise<void>((resolve: () => void, reject: (err: Error) => void) => {
-			camera.server.close(() => {
+			server.close(() => {
 				if (hadErrorClosingCameraSocket !== cameraSocketCloseExpectsError) {
 					let msg = 'camera socket unexpectedly closed '
 					msg += `with${hadErrorClosingCameraSocket ? '' : 'out'} error`
@@ -446,7 +513,7 @@ async function verifyInteractions(
 		})
 	}
 
-	const leftoverCameraIncomingBytes = await camera.readIncomingBytes(-1)
+	const leftoverCameraIncomingBytes = await (await camera).readIncomingBytes(-1)
 	if (leftoverCameraIncomingBytes.length > 0) {
 		throw new Error(`Camera received unexpected excess bytes: ${prettyBytes(leftoverCameraIncomingBytes)}`)
 	}
@@ -495,50 +562,5 @@ export async function RunCameraInteractionTest(
 		}
 	)
 
-	const instance = new MockInstance()
-	const clientViscaPort = new VISCAPort(instance)
-
-	const cameraPromise = new Promise<Camera>((resolve: (camera: Camera) => void) => {
-		server.once('connection', (socket: net.Socket) => {
-			LOG(`connection opened`)
-
-			const cameraIncomingBytes: number[] = []
-			let cameraSocketError = false
-			socket.once('error', (_err: Error) => {
-				cameraSocketError = true
-			})
-
-			let cameraReceivedMoreBytes = (async function cameraWaitToReceiveBytes() {
-				return new Promise<void>((resolve: () => void) => {
-					socket.once('data', (data: Buffer) => {
-						if (cameraSocketError) {
-							return
-						}
-
-						cameraIncomingBytes.push(...data)
-						resolve()
-
-						cameraReceivedMoreBytes = cameraWaitToReceiveBytes()
-					})
-				})
-			})()
-
-			async function readIncomingBytes(amount: number): Promise<readonly number[]> {
-				if (amount < 0) {
-					amount = cameraIncomingBytes.length
-				}
-				while (cameraIncomingBytes.length < amount) {
-					await cameraReceivedMoreBytes
-				}
-				return cameraIncomingBytes.splice(0, amount)
-			}
-
-			resolve({ server, socket, readIncomingBytes })
-		})
-	})
-
-	// Both port and camera must be ready before we can start testing.
-	const [_portReady, camera] = await Promise.all([clientViscaPort.open('127.0.0.1', port, true), cameraPromise])
-
-	return verifyInteractions(clientViscaPort, camera, instance, interactions, finalStatus)
+	return verifyInteractions(server, port, interactions, finalStatus)
 }

--- a/src/visca/__tests__/command-expands-to-include-terminator.test.ts
+++ b/src/visca/__tests__/command-expands-to-include-terminator.test.ts
@@ -1,7 +1,7 @@
 import { InstanceStatus } from '@companion-module/base'
 import { describe, test } from '@jest/globals'
 import { UserDefinedCommand } from '../command.js'
-import { CommandFailed, SendCommand } from './camera-interactions/interactions.js'
+import { CommandFailed, SendCommand, WaitUntilConnectedToCamera } from './camera-interactions/interactions.js'
 import { AttemptSendInvalidMatcher, MatchVISCABytes } from './camera-interactions/matchers.js'
 import { RunCameraInteractionTest } from './camera-interactions/run-test.js'
 
@@ -20,6 +20,13 @@ describe('terminator embedded in command via param', () => {
 			[
 				SendCommand(MyCustomCommand, { param: 'F' }, 'custom-command'),
 				CommandFailed([AttemptSendInvalidMatcher, MatchVISCABytes([0x81, 0xff, 0xff])], 'custom-command'),
+				// SendCommand usually implicitly waits for the connection to
+				// the camera to be established (and instance status to be
+				// updated).  But embedded terminators are detected before that
+				// waiting occurs, so instance status could still be Connecting
+				// here, and we must wait explicitly if the `InstanceStatus.Ok`
+				// at end of tests is to be guaranteed correct.
+				WaitUntilConnectedToCamera(),
 				// NOTE: No bytes are ever sent to (or received by) the camera.
 			],
 			InstanceStatus.Ok


### PR DESCRIPTION
This is one of those cases where it'd be really nice if someone were available to look over the change, with some prior knowledge of how the overall system works.

Barring that, at the very least hopefully someone who's hit the timeout can [manually install](https://github.com/bitfocus/companion-module-ptzoptics-visca/releases/tag/v3.0.0) the
[dont-delay-init.tar.gz](https://github.com/bitfocus/companion-module-ptzoptics-visca/files/15380311/dont-delay-init.tar.gz) I've created from this, to verify the problem is gone.  (You can verify the module installed correctly by clicking on the "?" in a connection config display and ensuring the module version is "3.0.1".)