### PR TITLE
Skip `y0 38 FF` if present at start of data

### DIFF
--- a/src/visca/__tests__/ack-without-pending-command.test.ts
+++ b/src/visca/__tests__/ack-without-pending-command.test.ts
@@ -4,6 +4,7 @@ import { FocusModeInquiry } from '../../camera/inquiries.js'
 import { ACK, FocusModeInquiryBytes } from './camera-interactions/bytes.js'
 import {
 	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
 	CameraReplyBytes,
 	InquiryFailedFatally,
 	SendInquiry,
@@ -15,6 +16,7 @@ describe('ACK without pending command', () => {
 	test('ACK with only inquiry pending', async () => {
 		return RunCameraInteractionTest(
 			[
+				CameraInitialNetworkChangeReply([0xf0, 0x38, 0xff]), // not essential to this test: randomly added to tests
 				SendInquiry(FocusModeInquiry, 'focus-mode'),
 				CameraExpectIncomingBytes(FocusModeInquiryBytes), // focus-mode
 				CameraReplyBytes(ACK(1)), // focus-mode

--- a/src/visca/__tests__/bad-inquiry-response.test.ts
+++ b/src/visca/__tests__/bad-inquiry-response.test.ts
@@ -4,6 +4,7 @@ import { ExposureModeInquiry } from '../../camera/inquiries.js'
 import { ExposureModeInquiryBytes } from './camera-interactions/bytes.js'
 import {
 	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
 	CameraReplyBytes,
 	InquiryFailed,
 	SendInquiry,
@@ -66,6 +67,7 @@ describe('inquiry response mismatch', () => {
 		const MaskMismatchResponseBytes = [0x90, 0x50, 0xf1, 0x02, 0x03, 0x04, 0xff]
 		return RunCameraInteractionTest(
 			[
+				CameraInitialNetworkChangeReply([0xc0, 0x38, 0xff]), // not essential to this test: randomly added to tests
 				SendInquiry(ZoomPositionInquiry, 'zoom-position'),
 				CameraExpectIncomingBytes(ZoomPositionInquiryBytes), // zoom-position
 				CameraReplyBytes(MaskMismatchResponseBytes), // zoom-position

--- a/src/visca/__tests__/camera-interactions/interactions.ts
+++ b/src/visca/__tests__/camera-interactions/interactions.ts
@@ -1,5 +1,6 @@
 import { CompanionOptionValues, InstanceStatus } from '@companion-module/base'
 import { Command, Inquiry } from '../../command.js'
+import { prettyBytes } from '../../utils.js'
 
 /**
  * A matcher defining the expected error message for a fatal or nonfatal failed
@@ -27,6 +28,11 @@ type SendCameraInquiry = {
 type CameraIncomingBytes = {
 	readonly type: 'camera-expect-incoming-bytes'
 	readonly bytes: readonly number[]
+}
+
+type CameraNetworkChangeReply = {
+	readonly type: 'camera-network-change'
+	readonly bytes: readonly [number, 0x38, 0xff]
 }
 
 type CameraReply = {
@@ -90,6 +96,7 @@ export type Interaction =
 	| SendCameraCommand
 	| SendCameraInquiry
 	| CameraIncomingBytes
+	| CameraNetworkChangeReply
 	| CameraReply
 	| CommandSuccess
 	| CommandFailure
@@ -161,6 +168,33 @@ export function SendInquiry(inquiry: Inquiry, id: string): SendCameraInquiry {
  */
 export function CameraExpectIncomingBytes(bytes: readonly number[]): CameraIncomingBytes {
 	return { type: 'camera-expect-incoming-bytes', bytes }
+}
+
+/**
+ * Make the "camera" send a Network Change Reply identifying as the desired
+ * camera.  (These must be the first reply bytes sent by the camera.)
+ *
+ * PTZOptics cameras don't send a Network Change Reply, but it appears that some
+ * [non-PTZOptics](https://www.sony.net/Products/CameraSystem/CA/BRC_X400_SRG_X400/Technical_Document/E042100111.pdf)
+ * [cameras](https://communication.aver.com/DownloadFile.aspx?n=5174%7C0C0D934C-A84C-423C-A14F-42C5F322C8AD&t=ServiceDownload)
+ * send an initial "y0 38 FF" (y = Device address + 8) at startup to indicate
+ * the camera's address to controllers.  (This device address is only meaningful
+ * for VISCA *not* over IP, for example RS-232 with daisy-chained cameras, hence
+ * why Sony cameras don't send it for VISCA over IP.  Other manufacturers'
+ * cameras, it appears, are not so well-behaved.)
+ *
+ * As long as it's not harming the primary PTZOptics use case to skip this
+ * initial network change reply, we might as well do it to allow using this
+ * module with more cameras.
+ *
+ * @param bytes
+ *   A network change reply sequence: `y0 38 FF` where `y = Device address + 8`.
+ */
+export function CameraInitialNetworkChangeReply(bytes: readonly [number, 0x38, 0xff]): CameraNetworkChangeReply {
+	if ((bytes[0] & 0xff) !== bytes[0] || (bytes[0] & 0b1000_1111) !== 0b1000_0000) {
+		throw new Error(`Bad lead byte in network change reply: ${prettyBytes(bytes)}`)
+	}
+	return { type: 'camera-network-change', bytes }
 }
 
 /** Make the "camera" reply with the given bytes. */

--- a/src/visca/__tests__/command-buffer-full.test.ts
+++ b/src/visca/__tests__/command-buffer-full.test.ts
@@ -9,6 +9,7 @@ import {
 } from './camera-interactions/bytes.js'
 import {
 	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
 	CameraReplyBytes,
 	CommandFailed,
 	CommandSucceeded,
@@ -21,6 +22,7 @@ describe('VISCA port command buffer full', () => {
 	test('command buffer full, resent', async () => {
 		return RunCameraInteractionTest(
 			[
+				CameraInitialNetworkChangeReply([0xa0, 0x38, 0xff]), // not essential to this test: randomly added to tests
 				SendCommand(OnScreenDisplayClose, 'close'),
 				CameraExpectIncomingBytes(OnScreenDisplayCloseBytes), // close
 				CameraReplyBytes(CommandBufferFullBytes), // close

--- a/src/visca/__tests__/completion-in-empty-socket.test.ts
+++ b/src/visca/__tests__/completion-in-empty-socket.test.ts
@@ -4,6 +4,7 @@ import { CameraPower, FocusLock } from '../../camera/commands.js'
 import { ACKCompletion, CameraPowerBytes, Completion, FocusLockBytes } from './camera-interactions/bytes.js'
 import {
 	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
 	CameraReplyBytes,
 	CommandFailedFatally,
 	CommandSucceeded,
@@ -16,6 +17,7 @@ describe('completion in empty socket', () => {
 	test('completion in never-used socket', async () => {
 		return RunCameraInteractionTest(
 			[
+				CameraInitialNetworkChangeReply([0x90, 0x38, 0xff]), // not essential to this test: randomly added to tests
 				SendCommand(CameraPower, { bool: 'on' }, 'camera-power'),
 				CameraExpectIncomingBytes(CameraPowerBytes), // camera-power
 				CameraReplyBytes(Completion(1)), // camera-power

--- a/src/visca/__tests__/network-change-reply.test.ts
+++ b/src/visca/__tests__/network-change-reply.test.ts
@@ -1,0 +1,56 @@
+import { InstanceStatus } from '@companion-module/base'
+import { describe, test } from '@jest/globals'
+import {
+	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
+	CameraReplyBytes,
+	CommandSucceeded,
+	InquirySucceeded,
+	InstanceStatusIs,
+	SendCommand,
+	SendInquiry,
+} from './camera-interactions/interactions.js'
+import { ACKCompletion, OnScreenDisplayCloseBytes, OnScreenDisplayInquiryBytes } from './camera-interactions/bytes.js'
+import { RunCameraInteractionTest } from './camera-interactions/run-test.js'
+import { OnScreenDisplayClose } from '../../camera/commands.js'
+import { OnScreenDisplayInquiry } from '../../camera/inquiries.js'
+
+describe('ignore initial network change reply', () => {
+	test('network change reply followed by command', async () => {
+		return RunCameraInteractionTest(
+			[
+				InstanceStatusIs(InstanceStatus.Connecting),
+				CameraInitialNetworkChangeReply([0x80, 0x38, 0xff]),
+				SendCommand(OnScreenDisplayClose, 'osd-close'),
+				CameraExpectIncomingBytes(OnScreenDisplayCloseBytes), // osd-close
+				CameraReplyBytes(ACKCompletion(1)), // osd-close
+				CommandSucceeded('osd-close'),
+			],
+			InstanceStatus.Ok
+		)
+	})
+
+	test('network change reply followed by inquiry', async () => {
+		return RunCameraInteractionTest(
+			[
+				InstanceStatusIs(InstanceStatus.Connecting),
+				// 90 is specially worth testing because 90 ... FF is the format
+				// of basic camera responses and inquiry responses -- it's just
+				// that none of those responses are ever 90 38 FF.
+				CameraInitialNetworkChangeReply([0x90, 0x38, 0xff]),
+				SendInquiry(OnScreenDisplayInquiry, 'osd-inquiry'),
+				CameraExpectIncomingBytes(OnScreenDisplayInquiryBytes), // osd-inquiry
+				CameraReplyBytes([0x90, 0x50, 0x02, 0xff]), // osd-inquiry
+				InquirySucceeded({ state: 'open' }, 'osd-inquiry'),
+			],
+			InstanceStatus.Ok
+		)
+	})
+
+	// We could test a network change reply on its own with no other
+	// interactions, but 1) it's kind of pointless because nobody wants to do
+	// that, 2) to properly test it we'd need to have VISCAPort notify that it's
+	// received and parsed through a reply that we're deliberately hiding, and
+	// 3) it's not relevant to PTZOptics cameras so it's hard to justify the
+	// effort.
+})

--- a/src/visca/__tests__/port-closed-early.test.ts
+++ b/src/visca/__tests__/port-closed-early.test.ts
@@ -5,6 +5,7 @@ import { ExposureModeInquiry } from '../../camera/inquiries.js'
 import { ACK, ExposureModeInquiryBytes, FocusNearStandardBytes, FocusStopBytes } from './camera-interactions/bytes.js'
 import {
 	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
 	CameraReplyBytes,
 	CloseVISCAPortEarly,
 	CommandFailedFatally,
@@ -37,6 +38,7 @@ describe('VISCA port closed early', () => {
 	test('manual close with half-completed command and inquiry waiting for initial response', async () => {
 		return RunCameraInteractionTest(
 			[
+				CameraInitialNetworkChangeReply([0xe0, 0x38, 0xff]), // not essential to this test: randomly added to tests
 				SendCommand(FocusNearStandard, 'focus-near'),
 				SendInquiry(ExposureModeInquiry, 'exposure-mode'),
 				CameraExpectIncomingBytes(FocusNearStandardBytes), // focus-near

--- a/src/visca/__tests__/return-message-syntax-errors.test.ts
+++ b/src/visca/__tests__/return-message-syntax-errors.test.ts
@@ -12,6 +12,7 @@ import {
 } from './camera-interactions/bytes.js'
 import {
 	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
 	CameraReplyBytes,
 	CommandFailedFatally,
 	InquiryFailedFatally,
@@ -78,6 +79,7 @@ describe('VISCA return message syntax errors', () => {
 		const BadReplyMatcher = MatchVISCABytes(BadReply)
 		return RunCameraInteractionTest(
 			[
+				CameraInitialNetworkChangeReply([0xb0, 0x38, 0xff]), // not essential to this test: randomly added to tests
 				SendCommand(FocusNearStandard, 'near'),
 				SendInquiry(ExposureModeInquiry, 'exposure-mode'),
 				SendInquiry(FocusModeInquiry, 'focus-mode'),

--- a/src/visca/__tests__/syntax-error-in-ack.test.ts
+++ b/src/visca/__tests__/syntax-error-in-ack.test.ts
@@ -4,6 +4,7 @@ import { FocusNearStandard } from '../../camera/commands.js'
 import { FocusNearStandardBytes } from './camera-interactions/bytes.js'
 import {
 	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
 	CameraReplyBytes,
 	CommandFailedFatally,
 	InstanceStatusIs,
@@ -33,6 +34,7 @@ describe('VISCA ACK syntax errors', () => {
 		const BadStartByte = [0x42]
 		return RunCameraInteractionTest(
 			[
+				CameraInitialNetworkChangeReply([0xb0, 0x38, 0xff]), // not essential to this test: randomly added to tests
 				SendCommand(FocusNearStandard, 'focus-near'),
 				CameraExpectIncomingBytes(FocusNearStandardBytes), // focus-near
 				InstanceStatusIs(InstanceStatus.Ok),

--- a/src/visca/__tests__/unexpected-inquiry-response.test.ts
+++ b/src/visca/__tests__/unexpected-inquiry-response.test.ts
@@ -5,6 +5,7 @@ import { FocusModeInquiry } from '../../camera/inquiries.js'
 import { ACK, FocusLockBytes, FocusModeInquiryBytes } from './camera-interactions/bytes.js'
 import {
 	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
 	CameraReplyBytes,
 	CommandFailedFatally,
 	InquirySucceeded,
@@ -49,6 +50,7 @@ describe('no pending inquiry', () => {
 		const InquiryResponse = [0x90, 0x50, 0x17 /* makes it an inquiry response */, 0xff]
 		return RunCameraInteractionTest(
 			[
+				CameraInitialNetworkChangeReply([0x90, 0x38, 0xff]), // not essential to this test: randomly added to tests
 				SendCommand(FocusLock, 'focus-lock'),
 				CameraExpectIncomingBytes(FocusLockBytes), // focus-lock
 				CameraReplyBytes(ACK(1)), // focus-lock

--- a/src/visca/__tests__/unrecognized-return-message.test.ts
+++ b/src/visca/__tests__/unrecognized-return-message.test.ts
@@ -4,6 +4,7 @@ import { OnScreenDisplayClose } from '../../camera/commands.js'
 import { OnScreenDisplayCloseBytes } from './camera-interactions/bytes.js'
 import {
 	CameraExpectIncomingBytes,
+	CameraInitialNetworkChangeReply,
 	CameraReplyBytes,
 	CommandFailedFatally,
 	SendCommand,
@@ -29,6 +30,7 @@ describe('unrecognized return message', () => {
 		const UnrecognizedError = [0x90, 0x60, 0x17, 0xff] // 17 not 41/03/02 as 60 requires
 		return RunCameraInteractionTest(
 			[
+				CameraInitialNetworkChangeReply([0xd0, 0x38, 0xff]), // not essential to this test: randomly added to tests
 				SendCommand(OnScreenDisplayClose, 'close'),
 				CameraExpectIncomingBytes(OnScreenDisplayCloseBytes), // close
 				CameraReplyBytes(UnrecognizedError), // close


### PR DESCRIPTION
This fixes #51 on the 3.0.x branch.

`y0 38 FF`, `y = device address + 8`, is present at start of data with some non-PTZOptics cameras, as a signal of what device address (a number 0-7) is associated with the camera in messages/replies _in serial connections_ (not VISCA over IP).

PTZOptics cameras don't act this way, so ignoring it with them is a no-op -- but will enable (without degrading the PTZOptics primary use case) some additional cameras to use this module.