### PR TITLE
Make parameters in the "Custom command" action work correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ptzoptics-visca",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"type": "module",
 	"main": "dist/main.js",
 	"scripts": {

--- a/src/custom-command-action.ts
+++ b/src/custom-command-action.ts
@@ -190,7 +190,7 @@ export function generateCustomCommandAction(instance: PtzOpticsInstance): Compan
 
 			const commandParams: CommandParams = parseParameters(commandBytes, String(options['command_parameters'])).reduce(
 				(acc, nibbles, i) => {
-					acc[`param_${i}`] = {
+					acc[`${i}`] = {
 						nibbles,
 						choiceToParam: Number,
 					}
@@ -203,9 +203,9 @@ export function generateCustomCommandAction(instance: PtzOpticsInstance): Compan
 			const command = new UserDefinedCommand(commandBytes, commandParams)
 
 			const commandOpts: CompanionOptionValues = {}
-			for (const key of Object.keys(commandParams)) {
-				const val = await context.parseVariablesInString(String(options[`parameter${key}`]))
-				commandOpts[`param_${key}`] = Number(val)
+			for (const i of Object.keys(commandParams)) {
+				const val = await context.parseVariablesInString(String(options[`parameter${i}`]))
+				commandOpts[i] = val
 			}
 
 			void instance.sendCommand(command, commandOpts)


### PR DESCRIPTION
The new user-defined parameters in custom commands don't work.  Instead of filling in a number the user fills in, it just fills in zeroes.

I think this broke during the [conversion to TypeScript](https://github.com/bitfocus/companion-module-ptzoptics-visca/commit/3837803c3baaada2dbaa2459f3018f538a1745c3) at a skim of that code.  TypeScript conversion wasn't targeted at v3.0.0, but then I had to rejigger my approach a bit and the mass of changes became functionally impossible to backport to a pre-TypeScript codebase with any degree of confidence in it so I ended up throwing in the towel.  Oh well.