### PR TITLE
feat: save preset from variable

### DIFF
--- a/src/actions-enum.ts
+++ b/src/actions-enum.ts
@@ -29,6 +29,7 @@ export enum PtzOpticsActionId {
 	ShutterDown = 'shutD',
 	SetShutter = 'shutS',
 	SetPreset = 'savePset',
+	SetPresetFromVar = 'savePsetFromVar',
 	RecallPreset = 'recallPset',
 	RecallPresetFromVar = 'recallPsetFromVar',
 	SetPresetDriveSpeed = 'speedPset',

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -318,6 +318,27 @@ export function getActions(instance: PtzOpticsInstance): CompanionActionDefiniti
 				void instance.sendCommand(PresetSave, event.options)
 			},
 		},
+		[PtzOpticsActionId.SetPresetFromVar]: {
+			name: 'Save Preset (by number)',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Preset Number',
+					id: PresetSaveOption.id,
+					useVariables: true,
+					tooltip: 'Preset number range of 0-89, 100-254',
+					default: '0',
+				},
+			],
+			callback: async ({ options }, context) => {
+				const errorOrValue = await parsePresetVariableOption(options, context)
+				if (typeof errorOrValue === 'string') {
+					instance.log('error', errorOrValue)
+				} else {
+					void instance.sendCommand(PresetSave, errorOrValue)
+				}
+			},
+		},
 		[PtzOpticsActionId.RecallPreset]: {
 			name: 'Recall Preset',
 			options: [


### PR DESCRIPTION
Similar to recall by variable, this adds the ability to save preset by variable.  Moved tests around slightly to group the common validity tests and then the recall and save tests.