### PR TITLE
add http status of Move SE

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
 		"node": "^18.12"
 	},
 	"dependencies": {
-		"@companion-module/base": "~1.10.0"
+		"@companion-module/base": "~1.10.0",
+		"digest-fetch": "^3.1.1",
+		"http-digest-client": "^0.0.3"
 	},
 	"devDependencies": {
 		"@companion-module/tools": "~2.0.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 	"dependencies": {
 		"@companion-module/base": "~1.10.0",
 		"digest-fetch": "^3.1.1",
-		"http-digest-client": "^0.0.3"
 	},
 	"devDependencies": {
 		"@companion-module/tools": "~2.0.4",

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,8 @@ export function getConfigFields(): SomeCompanionConfigField[] {
 			id: 'info',
 			width: 12,
 			label: 'Information',
-			value: 'This module controls PTZ cameras with VISCA over IP protocol',
+			value:
+				'This module controls PTZ cameras with VISCA over IP protocol. Optional You can activate a HTTP request for tally, standby and privacy status.',
 		},
 		{
 			type: 'textinput',
@@ -57,6 +58,30 @@ export function getConfigFields(): SomeCompanionConfigField[] {
 			default: '5678',
 			regex: Regex.PORT,
 			required: true,
+		},
+		{
+			type: 'number',
+			id: 'tally_poll_interval',
+			label: 'Status poll interval (ms, 0 = disabled)',
+			width: 6,
+			default: 0,
+			min: 0,
+			max: 60000,
+			step: 100,
+		},
+		{
+			type: 'textinput',
+			id: 'tally_username',
+			label: 'Username',
+			width: 6,
+			default: 'admin',
+		},
+		{
+			type: 'textinput',
+			id: 'tally_password',
+			label: 'Password',
+			width: 6,
+			default: '',
 		},
 		{
 			type: 'checkbox',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,6 +1238,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base-64@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "base-64@npm:0.1.0"
+  checksum: 10c0/fe0dcf076e823f04db7ee9b02495be08a91c445fbc6db03cb9913be9680e2fcc0af8b74459041fe08ad16800b1f65a549501d8f08696a8a6d32880789b7de69d
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -1355,6 +1362,13 @@ __metadata:
   version: 5.4.1
   resolution: "chalk@npm:5.4.1"
   checksum: 10c0/b23e88132c702f4855ca6d25cb5538b1114343e41472d5263ee8a37cccfccd9c4216d111e1097c6a27830407a1dc81fecdf2a56f2c63033d4dbbd88c10b0dcef
+  languageName: node
+  linkType: hard
+
+"charenc@npm:0.0.2":
+  version: 0.0.2
+  resolution: "charenc@npm:0.0.2"
+  checksum: 10c0/a45ec39363a16799d0f9365c8dd0c78e711415113c6f14787a22462ef451f5013efae8a28f1c058f81fc01f2a6a16955f7a5fd0cd56247ce94a45349c89877d8
   languageName: node
   linkType: hard
 
@@ -1485,6 +1499,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"crypt@npm:0.0.2":
+  version: 0.0.2
+  resolution: "crypt@npm:0.0.2"
+  checksum: 10c0/adbf263441dd801665d5425f044647533f39f4612544071b1471962209d235042fb703c27eea2795c7c53e1dfc242405173003f83cf4f4761a633d11f9653f18
+  languageName: node
+  linkType: hard
+
 "debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
@@ -1517,6 +1538,18 @@ __metadata:
   dependencies:
     clone: "npm:^1.0.2"
   checksum: 10c0/9cfbe498f5c8ed733775db62dfd585780387d93c17477949e1670bfcfb9346e0281ce8c4bf9f4ac1fc0f9b851113bd6dc9e41182ea1644ccd97de639fa13c35a
+  languageName: node
+  linkType: hard
+
+"digest-fetch@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "digest-fetch@npm:3.1.1"
+  dependencies:
+    base-64: "npm:^0.1.0"
+    js-sha256: "npm:^0.9.0"
+    js-sha512: "npm:^0.8.0"
+    md5: "npm:^2.3.0"
+  checksum: 10c0/c1f409a4a11406ea4161aef91236b326c8a366d7769ca100c18d7a19942af8f7e0d439734e83e53097ebda793f4baf6acb1664d1eaffc11bfcc0ec5808a3c0fb
   languageName: node
   linkType: hard
 
@@ -2326,6 +2359,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-digest-client@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "http-digest-client@npm:0.0.3"
+  checksum: 10c0/4696bc1c3b9d89591fbe91419b992f1cb93681447a83e87a4ddf8262b22f34d23a01acb4af270f9e8bcccfc329d2da8136739f92db981827048f11b973ee27ef
+  languageName: node
+  linkType: hard
+
 "http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
@@ -2421,6 +2461,13 @@ __metadata:
     jsbn: "npm:1.1.0"
     sprintf-js: "npm:^1.1.3"
   checksum: 10c0/331cd07fafcb3b24100613e4b53e1a2b4feab11e671e655d46dc09ee233da5011284d09ca40c4ecbdfe1d0004f462958675c224a804259f2f78d2465a87824bc
+  languageName: node
+  linkType: hard
+
+"is-buffer@npm:~1.1.6":
+  version: 1.1.6
+  resolution: "is-buffer@npm:1.1.6"
+  checksum: 10c0/ae18aa0b6e113d6c490ad1db5e8df9bdb57758382b313f5a22c9c61084875c6396d50bbf49315f5b1926d142d74dfb8d31b40d993a383e0a158b15fea7a82234
   languageName: node
   linkType: hard
 
@@ -2555,6 +2602,20 @@ __metadata:
   bin:
     jiti: lib/jiti-cli.mjs
   checksum: 10c0/4ceac133a08c8faff7eac84aabb917e85e8257f5ad659e843004ce76e981c457c390a220881748ac67ba1b940b9b729b30fb85cbaf6e7989f04b6002c94da331
+  languageName: node
+  linkType: hard
+
+"js-sha256@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "js-sha256@npm:0.9.0"
+  checksum: 10c0/f20b9245f6ebe666f42ca05536f777301132fb1aa7fbc22f10578fa302717a6cca507344894efdeaf40a011256eb2f7d517b94ac7105bd5cf087fa61551ad634
+  languageName: node
+  linkType: hard
+
+"js-sha512@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "js-sha512@npm:0.8.0"
+  checksum: 10c0/066fab16e14bd5dccff7c1cfca5961067ab00bb5e4eb0666d4fab8a669c0448663ccc982491cfe05f55cb693ed2722d40e6ee679a7b12e4006a6b358c17ddce8
   languageName: node
   linkType: hard
 
@@ -2806,6 +2867,17 @@ __metadata:
     promise-retry: "npm:^2.0.1"
     ssri: "npm:^12.0.0"
   checksum: 10c0/c40efb5e5296e7feb8e37155bde8eb70bc57d731b1f7d90e35a092fde403d7697c56fb49334d92d330d6f1ca29a98142036d6480a12681133a0a1453164cb2f0
+  languageName: node
+  linkType: hard
+
+"md5@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "md5@npm:2.3.0"
+  dependencies:
+    charenc: "npm:0.0.2"
+    crypt: "npm:0.0.2"
+    is-buffer: "npm:~1.1.6"
+  checksum: 10c0/14a21d597d92e5b738255fbe7fe379905b8cb97e0a49d44a20b58526a646ec5518c337b817ce0094ca94d3e81a3313879c4c7b510d250c282d53afbbdede9110
   languageName: node
   linkType: hard
 
@@ -3415,8 +3487,10 @@ __metadata:
     "@companion-module/base": "npm:~1.10.0"
     "@companion-module/tools": "npm:~2.0.4"
     "@types/node": "npm:^22.14.1"
+    digest-fetch: "npm:^3.1.1"
     eslint: "npm:~9.22.0"
     eslint-plugin-n: "npm:^17.17.0"
+    http-digest-client: "npm:^0.0.3"
     husky: "npm:^9.1.7"
     knip: "npm:^5.50.5"
     lint-staged: "npm:^15.5.1"


### PR DESCRIPTION
I wanted to have a feedback for the standby state of my PTZOptics Move SE. Since I don't know a lot about VISCA and inquiries (and the issues read like it's impossible), I analyzed the network traffic of the webinterface. Using this information I saw that got is already implemented, but it doesn't support digest.

Please give feedback to my chosen solution and if other cameras are supported or need more variables. I can imagine the the variables can be created after the first call, so that cameras with other data response can be easily supported, but I don't know if it is needed.